### PR TITLE
include cstdint (debian, gcc-13.2)

### DIFF
--- a/kaldifst/csrc/log.h
+++ b/kaldifst/csrc/log.h
@@ -4,6 +4,7 @@
 
 #ifndef KALDIFST_CSRC_LOG_H_
 #define KALDIFST_CSRC_LOG_H_
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
fixes: kaldifst-src/kaldifst/csrc/log.h:21:55: error: ‘uint32_t’ has not been declared