### PR TITLE
Use windows 2019 to build wheels for 64-bit windows

### DIFF
--- a/.github/workflows/build-wheels-win64.yaml
+++ b/.github/workflows/build-wheels-win64.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [windows-2019]
         python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
 
     steps:
@@ -42,6 +42,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
+          name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
       - name: Publish wheels to PyPI

--- a/.github/workflows/build-wheels-win64.yaml
+++ b/.github/workflows/build-wheels-win64.yaml
@@ -21,19 +21,26 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
-      # for a list of versions
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
-        env:
-          CIBW_BUILD: "${{ matrix.python-version}}-* "
-          CIBW_SKIP: "cp27-* cp35-* *-win32 pp* *-musllinux*"
-          CIBW_BUILD_VERBOSITY: 3
+        shell: bash
+        run: |
+          pip install setuptools wheel
+
+          python3 setup.py bdist_wheel
+
+          ls -lh ./dist/
+
+          mv dist wheelhouse
 
       - name: Display wheels
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(kaldifst CXX)
 
-set(KALDIFST_VERSION "1.7.11")
+set(KALDIFST_VERSION "1.7.12")
 
 # Disable warning about
 #


### PR DESCRIPTION
Otherwise, some users would have the following problems when using kaldifst with conda.

<img width="784" alt="image" src="https://github.com/k2-fsa/kaldifst/assets/5284924/9c4fa4d2-7092-4fd0-ac7e-dbdfee055026">
