### PR TITLE
support replacing homophonic phrases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif()
+
 if("x${CMAKE_SOURCE_DIR}" STREQUAL "x${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "\
 In-source build is not a good practice.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(kaldifst CXX)
 
-set(KALDIFST_VERSION "1.7.12")
+set(KALDIFST_VERSION "1.7.13")
 
 # Disable warning about
 #

--- a/kaldifst/csrc/text-normalizer.cc
+++ b/kaldifst/csrc/text-normalizer.cc
@@ -47,6 +47,42 @@ static fst::StdVectorFst StringToFst(const std::string &text) {
   return ans;
 }
 
+static fst::StdVectorFst StringToFst(
+    const std::vector<std::string> &words,
+    const std::vector<std::string> &pronunciations) {
+  using Weight = typename fst::StdArc::Weight;
+  using Arc = fst::StdArc;
+
+  fst::StdVectorFst ans;
+
+  auto s = ans.AddState();
+  ans.SetStart(s);
+
+  int32_t n = words.size();
+  for (int32_t i = 0; i != n; ++i) {
+    const auto &w = words[i];
+    const auto &p = pronunciations[i];
+    const uint8_t *w_ptr = reinterpret_cast<const uint8_t *>(w.data());
+    const uint8_t *p_ptr = reinterpret_cast<const uint8_t *>(p.data());
+
+    int32_t max_size = std::max<int32_t>(w.size(), p.size());
+
+    for (int32_t k = 0; k < max_size; ++k) {
+      uint8_t i_label = k < w.size() ? w_ptr[k] : 0;
+      uint8_t o_label = k < p.size() ? p_ptr[k] : 0;
+
+      const auto nextstate = ans.AddState();
+      ans.AddArc(s, Arc(i_label, o_label, Weight::One(), nextstate));
+      s = nextstate;
+    }
+  }
+
+  ans.SetFinal(s, Weight::One());
+  ans.SetProperties(fst::kCompiledStringProps, fst::kCompiledStringProps);
+
+  return ans;
+}
+
 static std::string FstToString(const fst::StdVectorFst &fst,
                                bool remove_output_zero) {
   std::string ans;
@@ -85,6 +121,50 @@ static std::string FstToString(const fst::StdVectorFst &fst,
   return ans;
 }
 
+static std::string FstToString2(const fst::StdVectorFst &fst) {
+  std::string ans;
+
+  using Weight = typename fst::StdArc::Weight;
+  using Arc = fst::StdArc;
+  auto s = fst.Start();
+  if (s == fst::kNoStateId) {
+    // this is an empty FST
+    return "";
+  }
+
+  while (fst.Final(s) == Weight::Zero()) {
+    fst::ArcIterator<fst::Fst<Arc>> aiter(fst, s);
+    if (aiter.Done()) {
+      // not reached final.
+      return "";
+    }
+
+    const auto &arc = aiter.Value();
+
+    if (arc.olabel != 0 && arc.olabel < 128) {
+      if (arc.ilabel != 0) {
+        ans.push_back(arc.ilabel);
+      }
+    } else if (arc.olabel >= 128) {
+      ans.push_back(arc.olabel);
+    }
+
+    s = arc.nextstate;
+    if (s == fst::kNoStateId) {
+      // Transition to invalid state";
+      return "";
+    }
+
+    aiter.Next();
+    if (!aiter.Done()) {
+      // not a linear FST
+      return "";
+    }
+  }
+
+  return ans;
+}
+
 TextNormalizer::TextNormalizer(const std::string &rule) {
   rule_ = std::unique_ptr<fst::StdConstFst>(
       CastOrConvertToConstFst(fst::ReadFstKaldiGeneric(rule)));
@@ -116,6 +196,27 @@ std::string TextNormalizer::Normalize(const std::string &s,
   fst::ShortestPath(composed_fst, &one_best, 1);
 
   return FstToString(one_best, remove_output_zero);
+}
+
+std::string TextNormalizer::Normalize(
+    const std::vector<std::string> &words,
+    const std::vector<std::string> &pronunciations) const {
+  if (words.size() != pronunciations.size()) {
+    return {};
+  }
+
+  // Step 1: Convert the input text into an FST
+  fst::StdVectorFst text = StringToFst(words, pronunciations);
+
+  // Step 2: Compose the input text with the rule FST
+  fst::StdVectorFst composed_fst;
+  fst::Compose(text, *rule_, &composed_fst);
+
+  // Step 3: Get the best path from the composed FST
+  fst::StdVectorFst one_best;
+  fst::ShortestPath(composed_fst, &one_best, 1);
+
+  return FstToString2(one_best);
 }
 
 }  // namespace kaldifst

--- a/kaldifst/csrc/text-normalizer.cc
+++ b/kaldifst/csrc/text-normalizer.cc
@@ -4,6 +4,7 @@
 
 #include "kaldifst/csrc/text-normalizer.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>

--- a/kaldifst/csrc/text-normalizer.h
+++ b/kaldifst/csrc/text-normalizer.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "fst/fst.h"
 #include "fst/fstlib.h"

--- a/kaldifst/csrc/text-normalizer.h
+++ b/kaldifst/csrc/text-normalizer.h
@@ -27,6 +27,9 @@ class TextNormalizer {
   std::string Normalize(const std::string &s,
                         bool remove_output_zero = true) const;
 
+  std::string Normalize(const std::vector<std::string> &words,
+                        const std::vector<std::string> &pronunciations) const;
+
  private:
   std::unique_ptr<fst::StdConstFst> rule_;
 };

--- a/kaldifst/python/csrc/text-normalizer.cc
+++ b/kaldifst/python/csrc/text-normalizer.cc
@@ -5,6 +5,7 @@
 #include "kaldifst/csrc/text-normalizer.h"
 
 #include <string>
+#include <vector>
 
 #include "kaldifst/python/csrc/text-normalizer.h"
 

--- a/kaldifst/python/csrc/text-normalizer.cc
+++ b/kaldifst/python/csrc/text-normalizer.cc
@@ -12,12 +12,20 @@ namespace kaldifst {
 
 void PybindTextNormalizer(py::module *m) {
   using PyClass = TextNormalizer;
+  using P = std::string (PyClass::*)(const std::string &, bool) const;
+  using P2 = std::string (PyClass::*)(const std::vector<std::string> &,
+                                      const std::vector<std::string> &) const;
+
   py::class_<PyClass>(*m, "TextNormalizer")
       .def(py::init<const std::string &>(), py::arg("rule"))
-      .def("normalize", &PyClass::Normalize, py::arg("s"),
+      .def("normalize", (P)(&PyClass::Normalize), py::arg("s"),
            py::arg("remove_output_zero") = true)
-      .def("__call__", &PyClass::Normalize, py::arg("s"),
-           py::arg("remove_output_zero") = true);
+      .def("__call__", (P)&PyClass::Normalize, py::arg("s"),
+           py::arg("remove_output_zero") = true)
+      .def("normalize", (P2)(&PyClass::Normalize), py::arg("words"),
+           py::arg("pronunciations"))
+      .def("__call__", (P2)&PyClass::Normalize, py::arg("words"),
+           py::arg("pronunciations"));
 }
 
 }  // namespace kaldifst


### PR DESCRIPTION
# Usage example

## 1. Generate an fst
```python3
import pynini

from pynini.lib import utf8, byte
sigma = utf8.VALID_UTF8_CHAR.star
from pynini import cdrewrite

zs = pynini.cross("zhang1san1", "章三")
ls = pynini.cross('li3si4', '理似')
rule = (zs | ls).optimize()
rule = cdrewrite(rule, "", "", sigma)

rule.write('replace.fst')
```

## 2. Use it
```python3
import kaldifst

lexicon = {
    "好": "hao3",
    "的": "de1",
    "可": "ke3",
    "以": "yi3",
    "张": "zhang1",
    "三": "san1",
    "章": "zhang1",
    "把": "ba3",
    "换": "huan4",
    "成": "cheng2",
    "吗": "ma1",
    "叁": "san1",
    "里": "li3",
    "四": "si4",
    "和": "he2",
}

text = "可以换成张叁和里四吗"

words = list(text)
pro = [lexicon[w] for w in text]

rule = kaldifst.TextNormalizer("./replace.fst")
t = rule(words, pro)
print(t)
```

The output is
```
可以换成章三和理似吗
```